### PR TITLE
Remove aligned focus styles

### DIFF
--- a/default.css
+++ b/default.css
@@ -31,12 +31,6 @@ select {
   font-family: inherit; /* apply body font family to "system" elements */
 }
 
-/* align focus styles across browsers */
-*:focus {
-  outline: 5px solid rgba(0, 103, 244, 0.247); /* Fallback for Safari which doesn't understand the auto keyword */
-  outline: 5px auto rgba(0, 103, 244, 0.247);
-}
-
 /* remove inner border on buttons in FF when focused */
 *::-moz-focus-inner {
   border-style: none;


### PR DESCRIPTION
It's better to respect the user's expectations, where the focus style
is the same regardless of website. Also, if custom focus styles are required
it should be the browser default that is overwritten, and not custom styles.