### PR TITLE
Add spacing between paragraphs

### DIFF
--- a/default.css
+++ b/default.css
@@ -52,6 +52,11 @@ select {
   padding: 0;
 }
 
+/* Make sure there is enough spacing beween paragraphs (WCAG AA 1.4.12) */
+p + p {
+  margin-top: 2em;
+}
+
 /* Remove animations, transitions for users who have turned them off in their OS */
 @media (prefers-reduced-motion: reduce) {
   * {


### PR DESCRIPTION
According to WCAG 2.1 AA specifications, criteria 1.4.12 spacing between text
paragraphs should be equivalent or larger than two times the font-size, ie. 2em in CSS.